### PR TITLE
Fixed form factory snippet and latte highlighting bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Latte.tmLanguage
+++ b/Latte.tmLanguage
@@ -165,7 +165,15 @@
 			<key>name</key>
 			<string>variable.other.global.latte</string>
 		</dict>
-		
+
+		<key>numbers</key> <!-- Numbers -->
+		<dict>
+			<key>match</key>
+			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b</string>
+			<key>name</key>
+			<string>constant.numeric.latte</string>
+		</dict>
+
 		<key>strings</key>  <!-- Strings -->
 		<dict>
 			<key>patterns</key>

--- a/Latte.tmLanguage
+++ b/Latte.tmLanguage
@@ -142,7 +142,7 @@
 				</dict>
 				<dict>  <!-- Whatever else between { and } -->
 					<key>match</key>
-					<string>([^}]|\s)</string>
+					<string>[a-zA-Z]+|[^}]|\s</string>
 					<key>name</key>
 					<string>source.latte</string>
 				</dict>

--- a/Snippets/UI/frm.sublime-snippet
+++ b/Snippets/UI/frm.sublime-snippet
@@ -10,7 +10,7 @@ protected function createComponent${1:Name}Form()
 
 	\$form->addSubmit('sub');
 
-	\$form->onSuccess[] = callback($this, 'process${1}Form');
+	\$form->onSuccess[] = callback(\$this, 'process${1}Form');
 
 	return \$form;
 }
@@ -18,7 +18,7 @@ protected function createComponent${1:Name}Form()
 /**
  * @param ${2:\Nette\Application\UI\Form}
  */
-public function process${1}Form(${2} $form)
+public function process${1}Form(${2} \$form)
 {
 	\$values = \$form->getValues();
 


### PR DESCRIPTION
When you insert Nette form component factory snippet, you can notice there are missing variables $this and $form in the code - there is just empty place instead of them. It's because that variable character has to be escaped.

Numbers weren't highlighted in latte, because there was numbers definition missing. I've copied regex from PHP syntax definition.

You have this Latte code: {control myForm}, there is "or" in the word Form highlighted, because it is a keyword. Fixed by updating a regex.
